### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -173,7 +173,7 @@ dependencies:
     - docutils==0.17.1
     - en-core-web-sm==3.0.0
     - entrypoints==0.3
-    - evaluate==0.2.2
+    - evaluate==0.3.0
     - fastrlock==0.6
     - filelock==3.0.12
     - flake8==3.9.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.